### PR TITLE
correct whitespace issue causing issues with fpm 0.8.2, fixes issue #2.

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -13,7 +13,7 @@ auto-examples = true
 [install]
 library = false
 
-[[ executable ]]
+[[executable]]
 name="to_f90"
 source-dir="app"
 main="to_f90.f90"


### PR DESCRIPTION
Remove unexpected whitespace, causing build issues with fpm 0.8.2. Resolves issue #2.